### PR TITLE
EPG scan methods

### DIFF
--- a/config.c
+++ b/config.c
@@ -497,6 +497,7 @@ cSetup::cSetup(void)
   ChannelsWrap = 0;
   ShowChannelNamesWithSource = 0;
   EmergencyExit = 1;
+  EPGScanType = 0;
 }
 
 cSetup& cSetup::operator= (const cSetup &s)
@@ -725,6 +726,7 @@ bool cSetup::Parse(const char *Name, const char *Value)
   else if (!strcasecmp(Name, "ChannelsWrap"))        ChannelsWrap       = atoi(Value);
   else if (!strcasecmp(Name, "ShowChannelNamesWithSource")) ShowChannelNamesWithSource = atoi(Value);
   else if (!strcasecmp(Name, "EmergencyExit"))       EmergencyExit      = atoi(Value);
+  else if (!strcasecmp(Name, "EPGScanType"))         EPGScanType        = atoi(Value);
   else if (!strcasecmp(Name, "LastReplayed"))        cReplayControl::SetRecording(Value);
   else
      return false;
@@ -857,6 +859,7 @@ bool cSetup::Save(void)
   Store("ChannelsWrap",       ChannelsWrap);
   Store("ShowChannelNamesWithSource", ShowChannelNamesWithSource);
   Store("EmergencyExit",      EmergencyExit);
+  Store("EPGScanType",        EPGScanType);
   Store("LastReplayed",       cReplayControl::LastReplayed());
 
   Sort();

--- a/config.h
+++ b/config.h
@@ -359,6 +359,7 @@ public:
   int ChannelsWrap;
   int ShowChannelNamesWithSource;
   int EmergencyExit;
+  int EPGScanType;
   int __EndData__;
   cString InitialChannel;
   cString DeviceBondings;

--- a/eitscan.c
+++ b/eitscan.c
@@ -176,6 +176,10 @@ void cEITScanner::Process(void)
                          }
                       }
                   }
+                  if(Setup.EPGScanType == 1) // use first device for EIT scan if device is idle
+                     break;
+                  else if(Setup.EPGScanType == 2 && AnyDeviceSwitched) // use first idle device for EIT scan
+                     break;
                }
            if (!AnyDeviceSwitched) {
               delete scanList;

--- a/vdr.c
+++ b/vdr.c
@@ -785,6 +785,8 @@ int main(int argc, char *argv[])
   Folders.Load(AddDirectory(ConfigDirectory, "folders.conf"));
   CamResponsesLoad(AddDirectory(ConfigDirectory, "camresponses.conf"), true);
 
+  isyslog("EPG scan type: %i", Setup.EPGScanType);
+
   if (!*cFont::GetFontFileName(Setup.FontOsd)) {
      const char *msg = "no fonts available - OSD will not show any text!";
      fprintf(stderr, "vdr: %s\n", msg);


### PR DESCRIPTION
There is a new setup parameter 'EPGScanType'.

This type defines the EPG scan behaviour:

0 - use VDR default EPG scan (scan all devices)
1 - use only the first device for EPG scan if it's idle
    No scanning will be done on other channels when watching Live TV.
2 - use the first idle device for scanning
    Only one additional device will be used for EPG scanning when watching
    Live TV

Why the heck am I doing this ?

My SAT>IP Server (Kathrein EXIP 418) periodically resets if all devices (4 in
my case) are permanently switching through all the channels. This patch
dramatically reduces the load on the SAT>IP server and makes it run happily.